### PR TITLE
Increase performance of svo/id generators

### DIFF
--- a/src/Qowaiv.CodeGeneration.SingleValueObjects/BaseGenerator.cs
+++ b/src/Qowaiv.CodeGeneration.SingleValueObjects/BaseGenerator.cs
@@ -1,5 +1,4 @@
 using Microsoft.CodeAnalysis;
-using System.Collections.Immutable;
 using System.Threading;
 
 namespace Qowaiv.CodeGeneration.SingleValueObjects;
@@ -17,8 +16,8 @@ public abstract class BaseGenerator<TParameters> : IIncrementalGenerator
     /// <inheritdoc />
     public void Initialize(IncrementalGeneratorInitializationContext context)
     {
-        var symbols = context.SyntaxProvider.ForAttributeWithMetadataName(MetadataName, Filter, Collect).Collect();
-        context.RegisterSourceOutput(symbols, Generate);
+        var symbols = context.SyntaxProvider.ForAttributeWithMetadataName(MetadataName, Filter, Collect);
+        context.RegisterSourceOutput(symbols, GenerateInternal);
     }
 
     /// <summary>Collects the SVO parameters.</summary>
@@ -34,14 +33,11 @@ public abstract class BaseGenerator<TParameters> : IIncrementalGenerator
     }
 
     /// <summary>Generates the source code for the SVO.</summary>
-    protected void Generate(SourceProductionContext context, ImmutableArray<TParameters> parameters)
+    private void GenerateInternal(SourceProductionContext context, TParameters pars)
     {
-        foreach (var pars in parameters)
-        {
-            var code = Generate(context, pars);
-            var ns = pars.Namespace.IsEmpty() ? "__global__" : pars.Namespace.ToString();
-            context.AddSource($"{ns}.{pars.Svo}.g.cs", code.ToString());
-        }
+        var code = Generate(context, pars);
+        var ns = pars.Namespace.IsEmpty() ? "__global__" : pars.Namespace.ToString();
+        context.AddSource($"{ns}.{pars.Svo}.g.cs", code.ToString());
     }
 
     /// <summary>Generates <see cref="Code"/> based on the parameters.</summary>

--- a/src/Qowaiv.CodeGeneration.SingleValueObjects/Qowaiv.CodeGeneration.SingleValueObjects.csproj
+++ b/src/Qowaiv.CodeGeneration.SingleValueObjects/Qowaiv.CodeGeneration.SingleValueObjects.csproj
@@ -52,8 +52,8 @@
     <Version>1.1.4</Version>
     <ToBeReleased>
       <![CDATA[
-v1.1.*
-?
+v1.1.5
+- Increased performance in projects with many generated types.
       ]]>
     </ToBeReleased>
     <PackageReleaseNotes>


### PR DESCRIPTION
There are two issues in current implementation:
1. ImmutableArray doesn't have "deep equality", so each time the generator runs (every keystroke) causes the generator to think the input changed. (see [here](https://andrewlock.net/creating-a-source-generator-part-9-avoiding-performance-pitfalls-in-incremental-generators/#4-watch-out-for-collection-types)).
2. **IF** ImmutableArray would be replaced with something that is actually equatable for caching purposes, the code for all SVO/IDs would be regenerated whenever any SVO/ID definition would change or whenever one would be added/removed

This change causes the caching to work properly and to be done for each individual SVO/ID, rather than all of them at once.

For my personal source generators, I usually at tests that:
1. Validate a snapshot of the output.
2. Check that for 2 consecutive runs on the same input code, the cached results were used, rather than regenerated.

If you want, I can add those kind of tests to the Qowaiv source generators as well (in the upcoming days).