### PR TITLE
Fraction.GetHashCode() must return consistant value

### DIFF
--- a/specs/Qowaiv.Specs/Mathematics/Fraction_specs.cs
+++ b/specs/Qowaiv.Specs/Mathematics/Fraction_specs.cs
@@ -429,6 +429,13 @@ public class Is_equal_by_value
             svo.GetHashCode().Should().Be(hash);
         }
     }
+
+    [Test]
+    public void hash_code_is_value_based_for_zero()
+    {
+        var zero = 17.DividedBy(42) - 17.DividedBy(42);
+        zero.GetHashCode().Should().Be(Fraction.Zero.GetHashCode());
+    }
 }
 public class Can_be_parsed
 {

--- a/src/Qowaiv/Mathematics/Fraction.cs
+++ b/src/Qowaiv/Mathematics/Fraction.cs
@@ -260,7 +260,10 @@ public readonly partial struct Fraction : IXmlSerializable, IFormattable, IEquat
 
     /// <inheritdoc/>
     [Pure]
-    public override int GetHashCode() => Hash.Code(denominator).And(numerator);
+    public override int GetHashCode()
+        => IsZero()
+        ? Hash.Code(0)
+        : Hash.Code(denominator).And(numerator);
 
     /// <inheritdoc/>
     [Pure]

--- a/src/Qowaiv/Qowaiv.csproj
+++ b/src/Qowaiv/Qowaiv.csproj
@@ -45,6 +45,7 @@
 v8.*
 - IBAN must not exceed 34 chars. (BUG)
 - IBAN for Russia has become more strict.
+- Fraction.GetHashCode() returns same value for all zero value's. (BUG)
 ]]>
     </ToBeReleased>
     <PackageReleaseNotes>


### PR DESCRIPTION
Co-pilot spotted that `Fraction.GetHashCode()` returned different values for `Fraction.Zero` and constructed zero values. This has been fixed.