### PR TITLE
Add obfuscation to IBAN

### DIFF
--- a/README.md
+++ b/README.md
@@ -347,6 +347,7 @@ iban.Country; // Country.NL
 iban.Length; // 18
 iban.ToString("F"); // NL20 INGB 0001 2345 67
 iban.ToString("H"); // NL20 INGB 0001 2345 67 (with non-breaking spaces).
+iban.ToString("O"); // NL20XXXXXXXXXX4567 (obfuscated).
 ```
 
 An overview with all supported countries and patterns can be found [here](IBAN.md).

--- a/specs/Qowaiv.Specs/Financial/InternationalBankAccountNumber_specs.cs
+++ b/specs/Qowaiv.Specs/Financial/InternationalBankAccountNumber_specs.cs
@@ -242,6 +242,10 @@ public class Has_custom_formatting
     [TestCase("F", "EE382200221020145685", /*........*/ "EE38 2200 2210 2014 5685")]
     [TestCase("F", "", "")]
     [TestCase("F", "?", "?")]
+    [TestCase("o", "NL20INGB0001234567", "nl20xxxxxxxxxx4567")]
+    [TestCase("O", "NL20INGB0001234567", "NL20XXXXXXXXXX4567")]
+    [TestCase("O", "", "")]
+    [TestCase("O", "?", "?")]
     public void with_format(string format, InternationalBankAccountNumber svo, string formatted)
         => svo.ToString(format).Should().Be(formatted);
 }

--- a/src/Qowaiv/Financial/InternationalBankAccountNumber.cs
+++ b/src/Qowaiv/Financial/InternationalBankAccountNumber.cs
@@ -111,7 +111,7 @@ public readonly partial struct InternationalBankAccountNumber : IXmlSerializable
     }
 
     /// <summary>
-    /// Masks sensitive parts of an IBANto protect user privacy. (eg: NL20XXXXXXXXXX4567).</summary>
+    /// Masks sensitive parts of an IBAN to protect user privacy (eg: NL20XXXXXXXXXX4567).</summary>
     [Pure]
     public string Obfuscated() => m_Value switch
     {

--- a/src/Qowaiv/Financial/InternationalBankAccountNumber.cs
+++ b/src/Qowaiv/Financial/InternationalBankAccountNumber.cs
@@ -43,7 +43,7 @@ public readonly partial struct InternationalBankAccountNumber : IXmlSerializable
     public Country Country => m_Value switch
     {
         null => Country.Empty,
-        _ when m_Value == Unknown.m_Value => Country.Unknown,
+        "ZZ" => Country.Unknown,
         _ => Country.Parse(m_Value[..2], CultureInfo.InvariantCulture),
     };
 
@@ -63,7 +63,7 @@ public readonly partial struct InternationalBankAccountNumber : IXmlSerializable
     public string MachineReadable() => m_Value switch
     {
         null => string.Empty,
-        _ when m_Value == Unknown.m_Value => "?",
+        "ZZ" => "?",
         _ => m_Value,
     };
 
@@ -84,24 +84,23 @@ public readonly partial struct InternationalBankAccountNumber : IXmlSerializable
     [Pure]
     public string HumanReadable(char space)
     {
-        if (m_Value == default)
+        return m_Value switch
         {
-            return string.Empty;
-        }
-        else if (m_Value == Unknown.m_Value)
-        {
-            return "?";
-        }
-        else
+            null => string.Empty,
+            "ZZ" => "?",
+            _ => Format(m_Value, space),
+        };
+
+        static string Format(string val, char space)
         {
             var index = 0;
             var pointer = 0;
-            var spacing = (m_Value.Length - 1) / 4;
-            var buffer = new char[m_Value.Length + spacing];
+            var spacing = (val.Length - 1) / 4;
+            var buffer = new char[val.Length + spacing];
 
-            while (index < m_Value.Length)
+            while (index < val.Length)
             {
-                buffer[pointer++] = m_Value[index++];
+                buffer[pointer++] = val[index++];
                 if ((index % 4) == 0 && pointer < buffer.Length)
                 {
                     buffer[pointer++] = space;
@@ -110,6 +109,16 @@ public readonly partial struct InternationalBankAccountNumber : IXmlSerializable
             return new(buffer);
         }
     }
+
+    /// <summary>
+    /// Masks sensitive parts of an IBANto protect user privacy. (eg: NL20XXXXXXXXXX4567).</summary>
+    [Pure]
+    public string Obfuscated() => m_Value switch
+    {
+        null => string.Empty,
+        "ZZ" => "?",
+        _ => m_Value[..4] + new string('X', m_Value.Length - 8) + m_Value[^4..],
+    };
 
     /// <summary>Returns a formatted <see cref="string" /> that represents the current IBAN.</summary>
     /// <param name="format">
@@ -128,6 +137,8 @@ public readonly partial struct InternationalBankAccountNumber : IXmlSerializable
     /// H: as human readable (with non-breaking spaces).
     /// f: as formatted lowercase.
     /// F: as formatted uppercase.
+    /// o: as obfuscated lowercase.
+    /// O: as obfuscated uppercase.
     /// </remarks>
     [Pure]
     public string ToString(string? format, IFormatProvider? formatProvider)
@@ -146,6 +157,8 @@ public readonly partial struct InternationalBankAccountNumber : IXmlSerializable
         ['H'] = (svo, _) => svo.HumanReadable(Nbsp),
         ['f'] = (svo, _) => svo.HumanReadable(' ').ToLowerInvariant(),
         ['F'] = (svo, _) => svo.HumanReadable(' '),
+        ['o'] = (svo, _) => svo.Obfuscated().ToLowerInvariant(),
+        ['O'] = (svo, _) => svo.Obfuscated(),
     };
 
     /// <summary>Gets an XML string representation of the IBAN.</summary>
@@ -183,7 +196,7 @@ public readonly partial struct InternationalBankAccountNumber : IXmlSerializable
             {
                 return true;
             }
-            if (str.IsUnknown(provider))
+            else if (str.IsUnknown(provider))
             {
                 result = Unknown;
                 return true;

--- a/src/Qowaiv/Qowaiv.csproj
+++ b/src/Qowaiv/Qowaiv.csproj
@@ -36,6 +36,7 @@
     <ToBeReleased>
       <![CDATA[
 v8.*
+- IBAN supports obfuscation with ToString("O").
 - IBAN parsing 1.75 times faster.
 - IBAN must not exceed 34 chars. (BUG)
 - IBAN for Russia has become more strict.


### PR DESCRIPTION
There are contexts where it is better to not show the full IBAN, to prevent exposure of sensitive data. With the format `"O"` (or `"o"`), an IBAN is obfuscated: `NL20XXXXXXXXXX4567`.