### PR TITLE
Set Clock.SetTimeForCurrentContext() using DateOnly

### DIFF
--- a/specs/Qowaiv.Specs/Clock_specs.cs
+++ b/specs/Qowaiv.Specs/Clock_specs.cs
@@ -82,6 +82,16 @@ public class For_current_execution_context_and_scope
     }
 
     [Test]
+    public void Can_Be_set_with_date_only()
+    {
+        using (Clock.SetTimeForCurrentContext(() => Svo.DateOnly))
+        {
+            Clock.UtcNow().Should().Be(Svo.Date);
+        }
+        Clock.UtcNow().Should().NotBe(Svo.Date);
+    }
+
+    [Test]
     public void TimeZone_can_be_set()
     {
         using (Clock.SetTimeZoneForCurrentContext(TestTimeZones.LeidenTime))
@@ -99,6 +109,18 @@ public class For_current_execution_context_and_scope
             Clock.TimeZone.Should().Be(Svo.TimeZone);
         }
         Clock.UtcNow().Should().NotBe(Svo.DateTime);
+        Clock.TimeZone.Should().NotBe(Svo.TimeZone);
+    }
+
+    [Test]
+    public void UtcNow_and_TimeZone_with_DateOnly()
+    {
+        using (Clock.SetTimeAndTimeZoneForCurrentContext(() => Svo.DateOnly, Svo.TimeZone))
+        {
+            Clock.UtcNow().Should().Be(Svo.Date);
+            Clock.TimeZone.Should().Be(Svo.TimeZone);
+        }
+        Clock.UtcNow().Should().NotBe(Svo.Date);
         Clock.TimeZone.Should().NotBe(Svo.TimeZone);
     }
 }

--- a/src/Qowaiv/Clock.cs
+++ b/src/Qowaiv/Clock.cs
@@ -126,7 +126,15 @@ public static class Clock
 
     /// <summary>Sets the <see cref="DateTime" /> function for current (execution) context only.</summary>
     [Impure]
+    [OverloadResolutionPriority(2)]
     public static IDisposable SetTimeForCurrentContext(Func<DateTime> time) => new TimeScope(time);
+
+#if NET8_0_OR_GREATER
+    /// <summary>Sets the <see cref="DateTime" /> function for current (execution) context only.</summary>
+    [Impure]
+    [OverloadResolutionPriority(1)]
+    public static IDisposable SetTimeForCurrentContext(Func<DateOnly> time) => new TimeScope(time.ToDateTime());
+#endif
 
     /// <summary>Sets the <see cref="TimeZoneInfo" /> for current (execution) context only.</summary>
     [Impure]
@@ -134,7 +142,15 @@ public static class Clock
 
     /// <summary>Sets the <see cref="DateTime" /> function and <see cref="TimeZoneInfo" /> for current (execution) context only.</summary>
     [Impure]
+    [OverloadResolutionPriority(2)]
     public static IDisposable SetTimeAndTimeZoneForCurrentContext(Func<DateTime> time, TimeZoneInfo timeZone) => new ClockScope(time, timeZone);
+
+#if NET8_0_OR_GREATER
+    /// <summary>Sets the <see cref="DateTime" /> function and <see cref="TimeZoneInfo" /> for current (execution) context only.</summary>
+    [Impure]
+    [OverloadResolutionPriority(1)]
+    public static IDisposable SetTimeAndTimeZoneForCurrentContext(Func<DateOnly> time, TimeZoneInfo timeZone) => new ClockScope(time.ToDateTime(), timeZone);
+#endif
 
     private static void SetLocalContextUtcNow(Func<DateTime>? time) => localContextUtcNow.Value = time;
 
@@ -200,6 +216,9 @@ public static class Clock
     }
 
 #if NET8_0_OR_GREATER
+    /// <summary>Converts a date provider to a time provider.</summary>
+    [Pure]
+    private static Func<DateTime> ToDateTime(this Func<DateOnly> time) => () => time().ToDateTime(TimeOnly.MinValue, DateTimeKind.Utc);
 
     /// <summary>
     /// Returns a <see cref="System.TimeProvider" /> implementation depending on

--- a/src/Qowaiv/Qowaiv.csproj
+++ b/src/Qowaiv/Qowaiv.csproj
@@ -31,11 +31,17 @@
   </ItemGroup>
   
   <PropertyGroup>
-    <Version>8.0.0</Version>
+    <Version>8.1.0</Version>
     <PackageValidationBaselineVersion>8.0.0</PackageValidationBaselineVersion>
     <ToBeReleased>
       <![CDATA[
 v8.*
+- ?
+]]>
+    </ToBeReleased>
+    <PackageReleaseNotes>
+      <![CDATA[
+v8.1.0
 - IBAN supports obfuscation with ToString("O").
 - IBAN parsing 1.75 times faster, with lower memory consumption.
 - IBAN must not exceed 34 chars. (BUG)
@@ -44,10 +50,7 @@ v8.*
 - Percentage JSON serialization speed improvements.
 - Fraction.GetHashCode() returns same value for all zero value's. (BUG)
 - [DebuggerDisplay("{DebuggerDisplay,nq}")] to drop quotes from debugger display.
-]]>
-    </ToBeReleased>
-    <PackageReleaseNotes>
-      <![CDATA[
+- Clock.SetTimeForCurrentContext() can be set using DateOnly.
 v8.0.0
 - Add support for .NET 10.
 - Add Clock.UtcToday().


### PR DESCRIPTION
As we advise `DateOnly` over `Date`, and only the latter can implicitly cast to `DateOnly`, having an overload to `Cock.SetTimeForCurrentContext()` that excepts `DateOnly` is beneficial.