### PR TITLE
Let Dependabot pull requests repair their own lock files

### DIFF
--- a/.github/workflows/dependabot-lock-files.yaml
+++ b/.github/workflows/dependabot-lock-files.yaml
@@ -11,9 +11,6 @@ on:
       - "**/*.csproj"
       - "**/packages.lock.json"
 
-permissions:
-  contents: read
-
 concurrency:
   group: dependabot-lock-files-${{ github.event.pull_request.number }}
   cancel-in-progress: true
@@ -23,22 +20,12 @@ jobs:
     name: Regenerate lock files
     if: github.actor == 'dependabot[bot]' && github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
-      # Has to be a Dependabot secret; GITHUB_TOKEN is read-only in Dependabot runs
-      # and pushes made with it do not trigger Build.
-      - name: Verify token
-        env:
-          LOCK_FILES_TOKEN: ${{ secrets.LOCK_FILES_TOKEN }}
-        run: |
-          if [ -z "$LOCK_FILES_TOKEN" ]; then
-            echo "::error::Missing Dependabot secret LOCK_FILES_TOKEN (fine-grained PAT, Contents: read and write)."
-            exit 1
-          fi
-
       - uses: actions/checkout@v7
         with:
           ref: ${{ github.event.pull_request.head.ref }}
-          token: ${{ secrets.LOCK_FILES_TOKEN }}
 
       - name: Setup .NET core versions
         uses: actions/setup-dotnet@v6
@@ -51,6 +38,8 @@ jobs:
       - name: Regenerate lock files
         run: dotnet restore qowaiv.slnx --force-evaluate
 
+      # A push made with GITHUB_TOKEN does not start a new Build run; the push to
+      # master after merging does.
       - name: Push lock files
         run: |
           if git diff --quiet -- '*packages.lock.json'; then

--- a/.github/workflows/dependabot-lock-files.yaml
+++ b/.github/workflows/dependabot-lock-files.yaml
@@ -1,15 +1,7 @@
 name: Dependabot lock files
 
-# Dependabot's NuGet updater restores a multi-targeting project one target framework
-# at a time. Each of those restores rewrites packages.lock.json with only the single
-# framework it was pinned to, so the lock files Dependabot commits lose every other
-# target framework and the locked-mode restore of the Build workflow fails with:
-#
-#   error NU1004: The project target frameworks are different than the lock file's
-#   target frameworks.
-#
-# That behaviour cannot be configured away from this side, so regenerate the lock
-# files for the whole solution and push them back onto the pull request.
+# Repairs packages.lock.json after a Dependabot update; Dependabot leaves it
+# broken for projects with more than two target frameworks.
 on:
   pull_request:
     branches:
@@ -32,16 +24,14 @@ jobs:
     if: github.actor == 'dependabot[bot]' && github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     steps:
-      # A push authenticated with the built-in GITHUB_TOKEN does not start a new
-      # workflow run, which would leave the corrected commit without a Build result.
-      # The token has to be a Dependabot secret: runs triggered by Dependabot resolve
-      # secrets.* against Dependabot secrets, not against Actions secrets.
+      # Has to be a Dependabot secret; GITHUB_TOKEN is read-only in Dependabot runs
+      # and pushes made with it do not trigger Build.
       - name: Verify token
         env:
           LOCK_FILES_TOKEN: ${{ secrets.LOCK_FILES_TOKEN }}
         run: |
           if [ -z "$LOCK_FILES_TOKEN" ]; then
-            echo "::error::Missing Dependabot secret LOCK_FILES_TOKEN. Add a fine-grained personal access token with 'Contents: read and write' on this repository under Settings > Secrets and variables > Dependabot."
+            echo "::error::Missing Dependabot secret LOCK_FILES_TOKEN (fine-grained PAT, Contents: read and write)."
             exit 1
           fi
 
@@ -58,15 +48,13 @@ jobs:
             9.x
             10.x
 
-      # --force-evaluate rewrites every lock file from the project graph, and takes
-      # precedence over the RestoreLockedMode that Directory.Build.props enables on CI.
       - name: Regenerate lock files
         run: dotnet restore qowaiv.slnx --force-evaluate
 
       - name: Push lock files
         run: |
           if git diff --quiet -- '*packages.lock.json'; then
-            echo "The lock files already cover every target framework."
+            echo "Lock files already up to date."
             exit 0
           fi
           git config user.name "github-actions[bot]"

--- a/.github/workflows/dependabot-lock-files.yaml
+++ b/.github/workflows/dependabot-lock-files.yaml
@@ -1,0 +1,76 @@
+name: Dependabot lock files
+
+# Dependabot's NuGet updater restores a multi-targeting project one target framework
+# at a time. Each of those restores rewrites packages.lock.json with only the single
+# framework it was pinned to, so the lock files Dependabot commits lose every other
+# target framework and the locked-mode restore of the Build workflow fails with:
+#
+#   error NU1004: The project target frameworks are different than the lock file's
+#   target frameworks.
+#
+# That behaviour cannot be configured away from this side, so regenerate the lock
+# files for the whole solution and push them back onto the pull request.
+on:
+  pull_request:
+    branches:
+      - master
+    paths:
+      - Directory.Packages.props
+      - "**/*.csproj"
+      - "**/packages.lock.json"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: dependabot-lock-files-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  lock-files:
+    name: Regenerate lock files
+    if: github.actor == 'dependabot[bot]' && github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    steps:
+      # A push authenticated with the built-in GITHUB_TOKEN does not start a new
+      # workflow run, which would leave the corrected commit without a Build result.
+      # The token has to be a Dependabot secret: runs triggered by Dependabot resolve
+      # secrets.* against Dependabot secrets, not against Actions secrets.
+      - name: Verify token
+        env:
+          LOCK_FILES_TOKEN: ${{ secrets.LOCK_FILES_TOKEN }}
+        run: |
+          if [ -z "$LOCK_FILES_TOKEN" ]; then
+            echo "::error::Missing Dependabot secret LOCK_FILES_TOKEN. Add a fine-grained personal access token with 'Contents: read and write' on this repository under Settings > Secrets and variables > Dependabot."
+            exit 1
+          fi
+
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          token: ${{ secrets.LOCK_FILES_TOKEN }}
+
+      - name: Setup .NET core versions
+        uses: actions/setup-dotnet@v6
+        with:
+          dotnet-version: |
+            8.x
+            9.x
+            10.x
+
+      # --force-evaluate rewrites every lock file from the project graph, and takes
+      # precedence over the RestoreLockedMode that Directory.Build.props enables on CI.
+      - name: Regenerate lock files
+        run: dotnet restore qowaiv.slnx --force-evaluate
+
+      - name: Push lock files
+        run: |
+          if git diff --quiet -- '*packages.lock.json'; then
+            echo "The lock files already cover every target framework."
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add -- '*packages.lock.json'
+          git commit -m "Regenerate packages.lock.json for all target frameworks"
+          git push


### PR DESCRIPTION
Dependabot leaves `packages.lock.json` broken on every NuGet update. So far that has been fixed by hand — #557, #578, #580, #584 and #598 all carry a second `lock files` commit; #576 didn't get one and was merged red.

Two upstream bugs, both in dependabot-core:

- [`LockFileUpdater`](https://github.com/dependabot/dependabot-core/blob/main/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Updater/LockFileUpdater.cs) has no callers, so nothing regenerates the lock files.
- `SdkProjectDiscovery` restores projects with more than two target frameworks once *per* framework, with `/p:TargetFramework=` pinned. Those run in parallel and race on the same lock file, and the winner leaves only its own framework behind. Hence NU1004 on exactly our seven multi-target projects, while the six single-target ones come out fine.

The NU1004 message reads back to front, which doesn't help: the list it labels *"Lock file target frameworks"* is what the project targets, and *"Project target frameworks"* is the single one left in the lock file.

This workflow runs `dotnet restore qowaiv.slnx --force-evaluate` on Dependabot PRs and pushes the result back. Verified on #600 and #601: after regeneration the diff against master is only the version bump, and a locked-mode Release build passes with 0 errors.

One wrinkle: a push made with `GITHUB_TOKEN` doesn't start a new workflow run, so Build won't re-run on the corrected commit — the PR just ends up with no Build result. Master has no required status checks, so that doesn't block the merge, and the push to master afterwards builds it. If we ever want the check back, swap the token for a PAT stored as a **Dependabot** secret (Actions secrets aren't visible to Dependabot runs).

To unblock #600 and #601: merge this, then `@dependabot rebase` on each.

Alternative, if you'd rather not run a workflow: get every project to two target frameworks or fewer. That's the threshold (`MaximumParallelTargetFrameworkRestores = 2`) at which Dependabot switches to a single unpinned restore and gets the lock files right on its own.